### PR TITLE
Fix browser loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ dist/zbar.wasm: $(ZBAR_DEPS) src/module.c dist/symbol.test.o
 	$(EMCC) $(EMCC_FLAGS) -o dist/zbar.js src/module.c $(ZBAR_INC) \
 		$(ZBAR_OBJS)
 	cp dist/zbar.wasm dist/zbar.wasm.bin
-	sed 's/"zbar.wasm"/"zbar.wasm.bin"/g' dist/zbar.js > dist/zbar.bin.js
 
 $(ZBAR_DEPS): $(ZBAR_SOURCE)/Makefile
 	cd $(ZBAR_SOURCE) && $(EMMAKE) make CFLAGS=-Os CXXFLAGS=-Os \

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "make",
-    "format": "git diff --cached --name-only --diff-filter=ACMR \"*.ts\" \"*.js\" | sed 's| |\\ |g' | xargs prettier --write",
+    "format": "git diff HEAD^ --name-only --diff-filter=ACMR \"*.ts\" \"*.js\" | sed 's| |\\ |g' | xargs prettier --write",
     "test": "jest --coverage"
   },
   "repository": {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -3,13 +3,8 @@ import ZBar from './ZBar';
 
 let inst: ZBar | null = null;
 
-const importObj = {
-  env: {
-  }
-};
-
 let instPromise = (async () => {
-  inst = await loadWasmInstance(importObj);
+  inst = await loadWasmInstance({});
   if (!inst) {
     throw Error('WASM was not loaded');
   }

--- a/src/load-browser.ts
+++ b/src/load-browser.ts
@@ -1,17 +1,27 @@
 /**
- * Webpack file-loader will not pack .wasm files correctly,
- * see https://github.com/webpack/webpack/issues/6725
- * Using extension .wasm.bin as a workaround. To facilitate
- * streaming compilation by the browser, .wasm.bin files
+ * Webpack trys to parse .wasm file even if file-loader is used. Using extension
+ * *.wasm.bin as a workaround.
+ * See https://github.com/webpack/webpack/issues/6725.
+ * To facilitate streaming compilation by the browser, *.wasm.bin files
  * should be served as MIME type 'application/wasm'.
  */
- import ZBar from './ZBar';
+// import wasmBinaryFile from './zbar.wasm';
+import wasmBinaryFileName from './zbar.wasm.bin';
+import ZBar from './ZBar';
+import instantiate from './zbar';
 
- const instantiate = require('./zbar.bin')
- 
- export const loadWasmInstance = async (
-   importObj: any
- ): Promise<ZBar | null> => {
-   return await instantiate(importObj);
- };
- 
+// locateFile is used to override the file path to the path provided by
+// file-loader.
+const locateFile = (file: string, _scriptDir: string) => {
+  if (file != 'zbar.wasm') {
+    console.error('Unexpected file:', file);
+  }
+  return wasmBinaryFileName;
+};
+
+export const loadWasmInstance = async (
+  importObj: any
+): Promise<ZBar | null> => {
+  importObj['locateFile'] = locateFile;
+  return await instantiate(importObj);
+};

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,6 +1,5 @@
 import ZBar from './ZBar';
-
-const instantiate = require('./zbar')
+import instantiate from './zbar';
 
 export const loadWasmInstance = async (
   importObj: any

--- a/src/test/browser.test.ts
+++ b/src/test/browser.test.ts
@@ -1,8 +1,0 @@
-import { loadWasmInstance }  from '../load-browser';
-
-test('WASM Instance', async () => {
-    const inst = await loadWasmInstance({});
-    expect(inst).not.toBeFalsy()
-    expect(inst?.HEAP8.byteLength).toBeGreaterThan(0)
-  });
-  

--- a/src/test/instance.test.ts
+++ b/src/test/instance.test.ts
@@ -1,7 +1,6 @@
 import { getInstance } from '../instance';
 
 test('WASM Instance', async () => {
-  const decoder = new TextDecoder();
   const inst = await getInstance();
   for (let i = 0; i < 100; ++i) {
     const ptr = inst._malloc(1000);

--- a/src/test/loader.test.ts
+++ b/src/test/loader.test.ts
@@ -1,0 +1,12 @@
+import instantiate from '../zbar';
+
+test('WASM Instance', async () => {
+  const inst = await instantiate({
+    locateFile: (file: string, scriptDir: string) => {
+      expect(file).toBe('zbar.wasm');
+      return scriptDir + 'zbar.wasm';
+    }
+  });
+  expect(inst).not.toBeFalsy();
+  expect(inst?.HEAP8.byteLength).toBeGreaterThan(0);
+});

--- a/src/zbar.d.ts
+++ b/src/zbar.d.ts
@@ -1,0 +1,3 @@
+import ZBar from './ZBar';
+declare const instantiate: (importObj: any) => Promise<ZBar>;
+export default instantiate;


### PR DESCRIPTION
Fix browser loader script. Use import instead of require.
Function `locateFile` is used to override the wasm binary path. With
that we can let webpack to serve the file for us.

TEST=Build and check with the demo page.