### PR TITLE
Add Deno support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,14 @@ jobs:
             dist/*.js
           if-no-files-found: error
 
-  build_ant_test_node:
+  build_and_test_node:
     needs: build_wasm
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node: [ '12', '14', '16', '17' ]
         include:
-          - node: 16
+          - node: '16'
             upload_artifact: true
     name: Build and test Node ${{ matrix.node }}
     steps:
@@ -47,14 +47,14 @@ jobs:
           name: wasm
           path: dist
       - run: npm install
-      - run: make .ts
-      - run: npm test
+      - run: make ts EM_DOCKER="false" ZBAR_WASM_DEPS=""
+      - run: make node-test EM_DOCKER="false" ZBAR_WASM_DEPS=""
       - uses: codecov/codecov-action@v2
       - name: Upload artifact
         if: ${{ matrix.upload_artifact }}
         uses: actions/upload-artifact@v2
         with:
-          name: dist
+          name: dist-node
           path: |
             dist/*.wasm
             dist/*.wasm.bin
@@ -63,7 +63,7 @@ jobs:
             dist/*.js
 
   publish_node:
-    needs: build_ant_test_node
+    needs: build_and_test_node
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -73,9 +73,72 @@ jobs:
           node-version: '16'
       - uses: actions/download-artifact@v2
         with:
-          name: dist
+          name: dist-node
           path: dist
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: ${{ github.event_name != 'release' }}
+
+  build_and_test_deno:
+    needs: build_wasm
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        deno: [ 'v1.16' ]
+        include:
+          - deno: 'v1.16'
+            upload_artifact: true
+    name: Build and test Deno ${{ matrix.deno }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: ${{ matrix.deno }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: wasm
+          path: dist
+      - run: make deno EM_DOCKER="false" ZBAR_WASM_DEPS=""
+      - run: make deno-test EM_DOCKER="false" ZBAR_WASM_DEPS=""
+      - uses: codecov/codecov-action@v2
+      - name: Upload artifact
+        if: ${{ matrix.upload_artifact }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-deno
+          path: |
+            dist/**/*.js
+            dist/**/*.ts
+
+  publish_deno:
+    needs: build_and_test_deno
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
+    steps:
+      - uses: webfactory/ssh-agent@v0.4.0
+        with:
+          ssh-private-key: ${{ secrets.DENO_REPO_KEY }}
+      - run: git clone git@github.com:zbar-wasm/zbar-wasm-deno.git
+      - run: |
+          cd zbar-wasm-deno
+          rm -rf dist
+          git checkout -- dist/README.md
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist-deno
+          path: zbar-wasm-deno/dist
+      - name: 'Update repo'
+        run: |
+          cd zbar-wasm-deno
+          git config user.name "zbar.wasm auto"
+          git config user.email "samsam2310@gmail.com"
+          git add .
+          git diff-index --quiet HEAD || git commit -m "Automatic publish from github.com/samsam2310/zbar.wasm"
+      - name: 'Deploy'
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          cd zbar-wasm-deno
+          git push origin main
+          git tag "${GITHUB_REF##*/}"
+          git push origin "${GITHUB_REF##*/}"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 ZBAR_VERSION = 0.23.90
 ZBAR_SOURCE = zbar-$(ZBAR_VERSION)
 SRC_DIR = ./src
-TS_SRC ::= $(shell find $(SRC_DIR) -name '*.ts')
 
 EM_VERSION = 3.0.0
-EM_DOCKER = docker run --rm -w /src -v $$PWD:/src emscripten/emsdk:$(EM_VERSION)
+EM_DOCKER = docker run --rm -u $(shell id -u):$(shell id -g) -w /src -v $$PWD:/src emscripten/emsdk:$(EM_VERSION)
 EMCC = $(EM_DOCKER) emcc
 # EMXX = $(EM_DOCKER) em++
 WASM2WAT = $(EM_DOCKER) wasm2wat
@@ -18,12 +17,53 @@ EMCC_FLAGS = -Os -Wall -Werror -s ALLOW_MEMORY_GROWTH=1 \
 	-s EXPORTED_FUNCTIONS="['_malloc','_free']" \
 	-s MODULARIZE=1 -s EXPORT_NAME=instantiate
 
-TSC = npx tsc
-TSC_FLAGS = -p ./
+ZBAR_WASM_DEPS = dist/zbar.wasm
 
-.PHONY: all debug clean .ts
+TSC := npx tsc
 
-all: dist/zbar.wasm .ts
+COMMON_TS_SRC := \
+	CppObject.ts \
+	enum.ts \
+	Image.ts \
+	ImageScanner.ts \
+	index.ts \
+	instance.ts \
+	module.ts \
+	Symbol.ts \
+	zbar.d.ts \
+	zbar.wasm.d.ts \
+	ZBarInstance.ts
+
+TS_SRC := \
+	$(COMMON_TS_SRC) \
+	load.ts \
+	load-browser.ts
+
+DENO_TS_SRC := \
+	$(COMMON_TS_SRC) \
+	test/Image.test.ts \
+	test/ImageScanner.test.ts \
+	test/instance.test.ts \
+	test/memorygrow.test.ts \
+	test/memoryleak.test.ts \
+	test/module.test.ts
+
+DENO_DENO_SRC := \
+	load.deno.ts \
+	deps/asserts.deno.ts \
+	deps/base64.deno.ts \
+	deps/canvas.deno.ts \
+	deps/expect.deno.ts \
+	deps/path.deno.ts \
+	test/utils.deno.ts
+
+DENO_FIX_IMPORT_TARGET := \
+	$(DENO_TS_SRC:%.ts=fiximport_%.deno.ts) \
+	$(DENO_DENO_SRC:%=fiximport_%)
+
+.PHONY: all debug clean ts deno $(DENO_FIX_IMPORT_TARGET)
+
+all: $(ZBAR_WASM_DEPS) ts deno node-test deno-test
 
 debug: $(ZBAR_DEPS) dist/zbar.wast src/module.c
 	$(EMCC) $(EMCC_FLAGS) -g2 -o dist/zbar-debug.js src/module.c $(ZBAR_INC) \
@@ -32,13 +72,15 @@ debug: $(ZBAR_DEPS) dist/zbar.wast src/module.c
 dist/symbol.test.o: $(ZBAR_DEPS) src/symbol.test.c
 	$(EMCC) -Wall -Werror -g2 -c src/symbol.test.c -o $@ $(ZBAR_INC)
 
-dist/zbar.wast: dist/zbar.wasm
+dist/zbar.wast: $(ZBAR_WASM_DEPS)
 	$(WASM2WAT) dist/zbar.wasm -o dist/zbar.wast
 
-dist/zbar.wasm: $(ZBAR_DEPS) src/module.c dist/symbol.test.o
+$(ZBAR_WASM_DEPS): $(ZBAR_DEPS) src/module.c dist/symbol.test.o
 	$(EMCC) $(EMCC_FLAGS) -o dist/zbar.js src/module.c $(ZBAR_INC) \
 		$(ZBAR_OBJS)
 	cp dist/zbar.wasm dist/zbar.wasm.bin
+
+dist/zbar.js: $(ZBAR_WASM_DEPS)
 
 $(ZBAR_DEPS): $(ZBAR_SOURCE)/Makefile
 	cd $(ZBAR_SOURCE) && $(EMMAKE) make CFLAGS=-Os CXXFLAGS=-Os \
@@ -51,6 +93,8 @@ $(ZBAR_SOURCE)/Makefile: $(ZBAR_SOURCE)/configure
 		--without-imagemagick --without-npapi --without-gtk \
 		--without-python --without-qt --without-xshm --disable-video \
 		--disable-pthread --disable-assert
+	cd $(ZBAR_SOURCE) && $(EMMAKE) make CFLAGS=-Os CXXFLAGS=-Os \
+		DEFS="-DZNO_MESSAGES -DHAVE_CONFIG_H"
 
 $(ZBAR_SOURCE)/configure: $(ZBAR_SOURCE).tar.gz
 	tar zxvf $(ZBAR_SOURCE).tar.gz
@@ -59,12 +103,39 @@ $(ZBAR_SOURCE)/configure: $(ZBAR_SOURCE).tar.gz
 $(ZBAR_SOURCE).tar.gz:
 	curl -L -o $(ZBAR_SOURCE).tar.gz https://linuxtv.org/downloads/zbar/zbar-$(ZBAR_VERSION).tar.gz
 
-.ts: $(TS_SRC)
-	$(TSC) $(TSC_FLAGS)
+ts: $(TS_SRC:%=src/%)
+	$(TSC) -p ./
+
+$(DENO_TS_SRC:%.ts=dist/%.deno.ts): $(DENO_TS_SRC:%=src/%)
+	mkdir -p $(dir $@)
+	cp $(@:dist/%.deno.ts=src/%.ts) $(@)
+
+$(DENO_DENO_SRC:%=dist/%): $(DENO_DENO_SRC:%=src/%)
+	mkdir -p $(dir $@)
+	cp $(@:dist/%=src/%) $(@)
+
+$(DENO_FIX_IMPORT_TARGET): $(DENO_FIX_IMPORT_TARGET:fiximport_%=dist/%)
+	scripts/deno-import.deno.ts $(@:fiximport_%=dist/%)
+
+dist/zbar.wasm.base64.deno.ts: dist/zbar.wasm
+	scripts/build-wasm-ts.deno.ts dist/zbar.wasm dist/zbar.wasm.base64.deno.ts
+
+dist/zbar.deno.js: dist/zbar.js
+	cp dist/zbar.js dist/zbar.deno.js
+	echo "export default instantiate;" >> dist/zbar.deno.js
+
+deno: $(DENO_FIX_IMPORT_TARGET) dist/zbar.wasm.base64.deno.ts dist/zbar.deno.js
+
+node-test: ts
+	npx jest --coverage
+
+deno-test: deno
+	deno test --coverage=coverage --allow-read */*.test.deno.ts */*/*.test.deno.ts
+	deno coverage ./coverage --lcov > coverage.lcov
 
 clean:
 	rm -f $(ZBAR_SOURCE).tar.gz
-	$(EM_DOCKER) rm -rf $(ZBAR_SOURCE)
+	rm -rf $(ZBAR_SOURCE)
 	rm -rf dist/test
 	rm -f dist/*.wasm
 	rm -f dist/*.bin

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "make",
     "format": "git diff HEAD^ --name-only --diff-filter=ACMR \"*.ts\" \"*.js\" | sed 's| |\\ |g' | xargs prettier --write",
-    "test": "jest --coverage"
+    "test": "make node-test"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-wasm-ts.deno.ts
+++ b/scripts/build-wasm-ts.deno.ts
@@ -1,0 +1,21 @@
+#!/bin/env -S deno run --allow-read --allow-write
+
+import { base64Encode } from '../src/deps/base64.deno.ts';
+
+const buildWasmTs = async (in_file: string, out_file: string) => {
+  const input = await Deno.readFile(in_file);
+  await Deno.writeTextFile(
+    out_file, `export default '${base64Encode(input)}';`);
+};
+
+const main = async () => {
+  if (Deno.args.length != 2) {
+    console.error(
+      `\nNo file argument.\nUsage: build-wasm-ts.deno.ts IN_FILE OUT_FILE`);
+    Deno.exit(1);
+  }
+  await buildWasmTs(Deno.args[0], Deno.args[1]);
+};
+
+if (import.meta.main)
+  main();

--- a/scripts/deno-import.deno.ts
+++ b/scripts/deno-import.deno.ts
@@ -1,0 +1,30 @@
+#!/bin/env -S deno run --allow-read --allow-write
+
+const IMPORT_RE =
+  /(import(?:[\s]+[^']+)*(?:[^{']*{[^}]+})? from '\.[\.]?\/)([^\.']+)'/g;
+const EXPORT_RE =
+  /(export \* from '\.\/)([^\.']+)'/g;
+
+const patchImport = (input: string): string => {
+  input = input.replaceAll(IMPORT_RE, '$1$2.deno.ts\'');
+  input = input.replaceAll(EXPORT_RE, '$1$2.deno.ts\'');
+  return input;
+}
+
+const patchImportOfFile = async (file: string) => {
+  const input = await Deno.readTextFile(file);
+  await Deno.writeTextFile(file, patchImport(input));
+};
+
+const main = async () => {
+  if (Deno.args.length != 1) {
+    console.error(`\nNo file argument.\nUsage: deno-import.deno.ts FILE`);
+    Deno.exit(1);
+  }
+  await patchImportOfFile(Deno.args[0]);
+};
+
+if (import.meta.main)
+  main();
+
+export { patchImport };

--- a/scripts/deno-import.test.deno.ts
+++ b/scripts/deno-import.test.deno.ts
@@ -1,0 +1,41 @@
+import { assertEquals } from '../src/deps/asserts.deno.ts';
+import { patchImport } from './deno-import.deno.ts';
+
+const TEST_FILE = `
+import ZBarInstance from './ZBarInstance';
+import TEST, { CppObject } from './CppObject';
+import {
+  ZBarSymbolType,
+  ZBarConfigType
+} from './enum';
+import TEST, {
+  ZBarSymbolType,
+  ZBarConfigType
+} from './enum';
+export * from './Image';
+import ZBarInstance from '../ZBarInstance';
+
+import ZBarInstance from './ZBarInstance.deno.ts';
+`;
+
+const EXPECT_TEST_FILE= `
+import ZBarInstance from './ZBarInstance.deno.ts';
+import TEST, { CppObject } from './CppObject.deno.ts';
+import {
+  ZBarSymbolType,
+  ZBarConfigType
+} from './enum.deno.ts';
+import TEST, {
+  ZBarSymbolType,
+  ZBarConfigType
+} from './enum.deno.ts';
+export * from './Image.deno.ts';
+import ZBarInstance from '../ZBarInstance.deno.ts';
+
+import ZBarInstance from './ZBarInstance.deno.ts';
+`;
+
+Deno.test('patchImport', () => {
+  const out = patchImport(TEST_FILE);
+  assertEquals(out, EXPECT_TEST_FILE);
+})

--- a/src/deps/asserts.deno.ts
+++ b/src/deps/asserts.deno.ts
@@ -1,0 +1,1 @@
+export { assertEquals } from 'https://deno.land/std@0.117.0/testing/asserts.ts';

--- a/src/deps/base64.deno.ts
+++ b/src/deps/base64.deno.ts
@@ -1,0 +1,6 @@
+import {
+  decode as base64Decode,
+  encode as base64Encode,
+} from 'https://deno.land/std@0.117.0/encoding/base64.ts';
+
+export { base64Decode, base64Encode };

--- a/src/deps/canvas.deno.ts
+++ b/src/deps/canvas.deno.ts
@@ -1,0 +1,1 @@
+export { createCanvas, loadImage } from 'https://deno.land/x/canvas@v1.3.0/mod.ts';

--- a/src/deps/expect.deno.ts
+++ b/src/deps/expect.deno.ts
@@ -1,0 +1,1 @@
+export { expect } from 'https://deno.land/x/expect@v0.2.9/mod.ts';

--- a/src/deps/path.deno.ts
+++ b/src/deps/path.deno.ts
@@ -1,0 +1,1 @@
+export * from 'https://deno.land/std@0.117.0/path/mod.ts';

--- a/src/load.deno.ts
+++ b/src/load.deno.ts
@@ -1,0 +1,11 @@
+import ZBarInstance from './ZBarInstance';
+import instantiate from './zbar.deno.js';
+import WASM_BASE64 from './zbar.wasm.base64.deno.ts';
+import { base64Decode } from './deps/base64.deno.ts';
+
+export const loadWasmInstance = async (
+  importObj: any
+): Promise<ZBarInstance | null> => {
+  importObj['wasmBinary'] = base64Decode(WASM_BASE64);
+  return await instantiate(importObj);
+};

--- a/src/module.ts
+++ b/src/module.ts
@@ -46,6 +46,12 @@ export const scanRGBABuffer = async (
   return res;
 };
 
+interface ImageData {
+  data: Uint8ClampedArray;
+  height: number;
+  width: number;
+};
+
 export const scanImageData = async (
   image: ImageData,
   scanner?: ImageScanner

--- a/src/test/Image.test.ts
+++ b/src/test/Image.test.ts
@@ -1,5 +1,6 @@
 import { Image } from '../Image';
 import { Symbol } from '../Symbol';
+import { test, expect } from './utils';
 
 test('Image', async () => {
   const data = new Uint8Array([128, 128, 128, 128]);

--- a/src/test/ImageScanner.test.ts
+++ b/src/test/ImageScanner.test.ts
@@ -2,6 +2,7 @@ import { Image } from '../Image';
 import { ImageScanner } from '../ImageScanner';
 import { Symbol } from '../Symbol';
 import { ZBarSymbolType, ZBarConfigType } from '../enum';
+import { test, expect } from './utils';
 
 test('ImageScanner', async () => {
   const data = new Uint8Array([128, 128, 128, 128]);

--- a/src/test/instance.test.ts
+++ b/src/test/instance.test.ts
@@ -1,4 +1,5 @@
 import { getInstance } from '../instance';
+import { test, expect } from './utils';
 
 test('WASM Instance', async () => {
   const inst = await getInstance();

--- a/src/test/loader.test.ts
+++ b/src/test/loader.test.ts
@@ -1,4 +1,5 @@
 import instantiate from '../zbar';
+import { test, expect } from './utils';
 
 test('WASM Instance', async () => {
   const inst = await instantiate({

--- a/src/test/memorygrow.test.ts
+++ b/src/test/memorygrow.test.ts
@@ -1,12 +1,12 @@
 import { getImageData } from './utils';
 import { getInstance } from '../instance';
 import { scanImageData } from '../module';
+import { test, expect } from './utils';
 
 test('Multiple Scan Test', async () => {
   const inst = await getInstance();
-  const dir = __dirname + '/../../src/test';
   let res;
-  const img4 = await getImageData(dir + '/test4.png');
+  const img4 = await getImageData('/test4.png');
   res = await scanImageData(img4);
   expect(res).toHaveLength(2);
 
@@ -19,7 +19,7 @@ test('Multiple Scan Test', async () => {
   let b2 = inst.HEAP8.buffer;
   expect(b2).not.toBe(b1);
   b1 = b2;
-  
+
   for (let i = 0; i < 100; ++i) {
     res = await scanImageData(img4);
     expect(res).toHaveLength(2);
@@ -29,7 +29,8 @@ test('Multiple Scan Test', async () => {
     b2 = inst.HEAP8.buffer;
   }
 
-  // Note: memory buffer and views may not need to be updated on *every* _malloc() call
+  // Note: memory buffer and views may not need to be updated on *every*
+  // _malloc() call.
   expect(b2).not.toBe(b1);
   inst._free(bfr);
 });

--- a/src/test/memoryleak.test.ts
+++ b/src/test/memoryleak.test.ts
@@ -1,12 +1,12 @@
 import { getImageData } from './utils';
 import { getInstance } from '../instance';
 import { scanImageData } from '../module';
+import { test, expect } from './utils';
 
 test('Multiple Scan Test', async () => {
   const inst = await getInstance();
-  const dir = __dirname + '/../../src/test';
   let res;
-  const img4 = await getImageData(dir + '/test4.png');
+  const img4 = await getImageData('/test4.png');
   res = await scanImageData(img4);
   expect(res).toHaveLength(2);
   const b = inst.HEAP8.buffer;

--- a/src/test/module.test.ts
+++ b/src/test/module.test.ts
@@ -2,11 +2,11 @@ import { getImageData, imageDataToGrayBuffer } from './utils';
 import { ImageScanner } from '../ImageScanner';
 import { scanImageData, scanGrayBuffer, getDefaultScanner } from '../module';
 import { ZBarSymbolType, ZBarConfigType } from '../enum';
+import { test, expect } from './utils';
 
 test('scanImageData', async () => {
-  const dir = __dirname + '/../../src/test';
   let res;
-  const img1 = await getImageData(dir + '/test1.png');
+  const img1 = await getImageData('/test1.png');
   res = await scanImageData(img1);
   expect(res).toHaveLength(1);
   expect(res[0].type).toEqual(ZBarSymbolType.ZBAR_QRCODE);
@@ -30,15 +30,15 @@ test('scanImageData', async () => {
     { x: 1676, y: 313 }
   ]);
 
-  res = await scanImageData(await getImageData(dir + '/test2.png'));
+  res = await scanImageData(await getImageData('/test2.png'));
   expect(res).toHaveLength(1);
   expect(res[0].type).toEqual(ZBarSymbolType.ZBAR_QRCODE);
   expect(res[0].decode()).toEqual('中文測試');
 
-  res = await scanImageData(await getImageData(dir + '/test3.png'));
+  res = await scanImageData(await getImageData('/test3.png'));
   expect(res).toHaveLength(0);
 
-  res = await scanImageData(await getImageData(dir + '/test4.png'));
+  res = await scanImageData(await getImageData('/test4.png'));
   expect(res).toHaveLength(2);
   expect(res[0].type).toEqual(ZBarSymbolType.ZBAR_QRCODE);
   expect(res[0].decode()).toEqual('First');
@@ -47,9 +47,8 @@ test('scanImageData', async () => {
 });
 
 test('Barcode', async () => {
-  const dir = __dirname + '/../../src/test';
   let res;
-  const img5 = await getImageData(dir + '/test5.png');
+  const img5 = await getImageData('/test5.png');
   res = await scanImageData(img5);
   expect(res).toHaveLength(1);
   expect(res[0].type).toEqual(ZBarSymbolType.ZBAR_EAN13);

--- a/src/test/utils.deno.ts
+++ b/src/test/utils.deno.ts
@@ -1,12 +1,21 @@
-import { createCanvas, loadImage } from 'canvas';
+import { createCanvas, loadImage } from '../deps/canvas.deno.ts';
+import { expect } from '../deps/expect.deno.ts';
+import * as path from '../deps/path.deno.ts';
 
 export const getImageData = async (file: string) => {
-  const dir = __dirname + '/../../src/test';
+  const dir = path.join(
+    path.fromFileUrl(import.meta.url), '..', '..', '..', 'src', 'test');
   const img = await loadImage(dir + file);
-  const canvas = createCanvas(img.width, img.height);
+  const canvas = createCanvas(img.width(), img.height());
   const ctx = canvas.getContext('2d');
   ctx.drawImage(img, 0, 0);
-  return ctx.getImageData(0, 0, img.width, img.height);
+  return ctx.getImageData(0, 0, img.width(), img.height());
+};
+
+interface ImageData {
+  data: Uint8ClampedArray;
+  height: number;
+  width: number;
 };
 
 export const imageDataToGrayBuffer = (img: ImageData) => {
@@ -22,7 +31,6 @@ export const imageDataToGrayBuffer = (img: ImageData) => {
   return buf;
 };
 
-const jestTest = test;
-const jestExpect = expect;
+const test = Deno.test;
 
-export { jestTest as test, jestExpect as expect };
+export { test, expect };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,5 +65,11 @@
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "**/*.deno.ts"
+  ],
 }


### PR DESCRIPTION
Deno require some different syntax from typescript. Add deno files as
*.deno.ts to seperate them from other ts files.

* Deno files are rename to *.deno.ts when building.
* Import path is changed to *.deno.ts when building because deno
requires to have extension but typescript requires to not have.
* Some files are changed to run on both node and deno.
* Deno dist files are deploy to another github repo for the users to
import.